### PR TITLE
Add null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 1.0.0 - December 23, 2018
 
 - First Release
+
+## 2.0.0 September 2, 2021
+
+- Add null safety

--- a/lib/adler32.dart
+++ b/lib/adler32.dart
@@ -7,7 +7,7 @@ import 'src/util.dart';
 /// Main class that contains all 3 functions
 abstract class Adler32 {
   /// Get checksum from a binary string
-  static int bstr(String bstr, [int seed]) {
+  static int bstr(String bstr, [int? seed]) {
     int a = 1, b = 0, L = bstr.length, M = 0;
     if (seed != null) {
       a = seed & 0xFFFF;
@@ -26,7 +26,7 @@ abstract class Adler32 {
   }
 
   /// Get checksum from a array of bites
-  static int buf(List<int> buf, [int seed]) {
+  static int buf(List<int> buf, [int? seed]) {
     int a = 1, b = 0, L = buf.length, M = 0;
     if (seed != null) {
       a = seed & 0xFFFF;
@@ -45,7 +45,7 @@ abstract class Adler32 {
   }
 
   /// Get checksum from a regular string
-  static int str(String str, [int seed]) {
+  static int str(String str, [int? seed]) {
     int a = 1, b = 0, L = str.length, M = 0, c = 0, d = 0;
     if (seed != null) {
       a = seed & 0xFFFF;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: adler32
-version: 1.0.0
+version: 2.0.0
 author: Volk <templar.volk@yandex.com>
 description: Signed ADLER-32 algorithm implementation in Dart. Works in browser, VM and flutter.
 homepage: https://github.com/TemplarVolk/ADLER32
 environment:
-  sdk: '>=1.0.0 <3.0.0'
+  sdk: '>=2.13.4 <3.0.0'
 dev_dependencies:
   test: ^1.5.1


### PR DESCRIPTION
Please can you add these simple changes to your repo and please also publish this version to pub.dev.

I am trying to publish my repo [rockvole_db_replicator](https://github.com/Rockvole/rockvole_db_replicator) to pub.dev, but I get one error :
```
Package validation found the following potential issue:
* This package is opting into null-safety, but a dependency or file is not.
  
  package:adler32 is not opted into null safety in its pubspec.yaml:
    ╷
  7 │   sdk: '>=1.0.0 <3.0.0'
    │        ^^^^^^^^^^^^^^^^
    ╵
  
  Note that by publishing with non-migrated dependencies your package may be
  broken at any time if one of your dependencies migrates without a breaking 
  change release. 
  
  We highly recommend that you wait until all of your dependencies have been 
  migrated before publishing.
  
  Run `pub outdated --mode=null-safety` for more information about the state of
  dependencies.
  
  See https://dart.dev/null-safety/migration-guide
  for more information about migrating.
```